### PR TITLE
Update CherryPy Dependency for python2 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ from version import version
 # change requirements according to python version
 if sys.version_info[0] == 2:
     install_requires = [
-        'CherryPy >= 3.0.0',
+        'CherryPy >= 3.0.0, < 18.0.0',
         'python-ldap',
         'PyYAML',
         'Mako'


### PR DESCRIPTION
According to CherryPy's Pypi page, CherryPy does not support Python2 anymore starting in version 18.0.0. Indeed, an error appears at runtime. 

This PR fixes this problem by enforcing a version < 18.0.0 to CherryPy